### PR TITLE
Add Support for PostbackCommands

### DIFF
--- a/src/Postback/PostbackCommand.php
+++ b/src/Postback/PostbackCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tgallice\FBMessenger\Postback;
+
+use Tgallice\FBMessenger;
+use Tgallice\FBMessenger\Messenger;
+use Tgallice\FBMessenger\NotificationType;
+use Tgallice\FBMessenger\Callback\PostbackEvent;
+use Tgallice\FBMessenger\Model\Callback\Postback;
+
+/**
+ * Class PostbackCommand
+ * @package Tgallice\FBMessenger\Postback
+ */
+abstract class PostbackCommand
+{
+
+    /**
+     * @var Messenger
+     */
+    protected $messenger;
+
+    /**
+     * @var PostbackEvent
+     */
+    protected $event;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @return string
+     */
+    public function getName(){
+        return $this->name;
+    }
+
+    /**
+     * @return Postback
+     */
+    public function getPostback()
+    {
+        return $this->event->getPostback();
+    }
+
+    /**
+     * @return Messenger
+     */
+    public function getMessenger()
+    {
+        return $this->messenger;
+    }
+
+    /**
+     * @return PostbackEvent
+     */
+    public function getEvent()
+    {
+        return $this->event;
+    }
+
+    /**
+     * @param $message
+     * @param string $notificationType
+     */
+    public function replyWithMessage($message, $notificationType = NotificationType::REGULAR)
+    {
+        $this->messenger->sendMessage($this->event->getSenderId(), $message, $notificationType);
+    }
+
+    /**
+     * @param $messenger
+     * @param $event
+     * @return mixed
+     */
+    public function initialize($messenger, $event)
+    {
+        $this->messenger = $messenger;
+        $this->event = $event;
+
+        return $this->run();
+    }
+
+    /**
+     * @return mixed
+     */
+    abstract public function run();
+}

--- a/src/Postback/StartPostbackCommand.php
+++ b/src/Postback/StartPostbackCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tgallice\FBMessenger\Postback;
+
+/**
+ * Class StartPostbackCommand
+ * @package Tgallice\FBMessenger\Postback
+ */
+class StartPostbackCommand extends PostbackCommand
+{
+    /**
+     * @var string
+     */
+    protected $name = 'start';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run()
+    {
+        $this->replyWithMessage('Welcome!');
+    }
+}


### PR DESCRIPTION
I haven't test this yet.
Use

```
$webookHandler = new Tgallice\FBMessenger\WebhookRequestHandler($messenger, <your_secret>,<verify_token>);
$webookHandler>addPostbackCommand(Tgallice\FBMessenger\Postback\StartPostbackCommand::class);
```