### PR TITLE
bugfix: attachments are not properly parsed

### DIFF
--- a/spec/CallbackEventFactorySpec.php
+++ b/spec/CallbackEventFactorySpec.php
@@ -40,12 +40,13 @@ class CallbackEventFactorySpec extends ObjectBehavior
               "message":{
                 "mid":"mid.1457764197618:41d102a3e1ae206a38",
                 "seq":73,
+                "attachments": [{"type": "image", "url": "http://domain.com/example.jpg"}],
                 "text":"hello, world!",
                 "quick_reply": {
                   "payload": "DEVELOPER_DEFINED_PAYLOAD"
                 }
               }
-            }    
+            }
         ';
 
         $arr = json_decode($raw, true);
@@ -54,6 +55,10 @@ class CallbackEventFactorySpec extends ObjectBehavior
 
         $event = $this::createMessageEvent($arr);
         $event->shouldBeLike($expectedEvent);
+        $event->getMessage()->getAttachments()->shouldBeLike([[
+			"type" => "image",
+			"url" => "http://domain.com/example.jpg"
+		]]);
 
         $event2 = $this::create($arr);
         $event2->shouldBeLike($expectedEvent);
@@ -73,7 +78,7 @@ class CallbackEventFactorySpec extends ObjectBehavior
               "postback":{
                 "payload":"USER_DEFINED_PAYLOAD"
               }
-            }    
+            }
         ';
 
         $arr = json_decode($raw, true);
@@ -101,7 +106,7 @@ class CallbackEventFactorySpec extends ObjectBehavior
               "optin":{
                 "ref":"PASS_THROUGH_PARAM"
               }
-            } 
+            }
         ';
 
         $arr = json_decode($raw, true);
@@ -130,7 +135,7 @@ class CallbackEventFactorySpec extends ObjectBehavior
                 "status":"linked",
                 "authorization_code":"PASS_THROUGH_AUTHORIZATION_CODE"
               }
-            }  
+            }
         ';
 
         $arr = json_decode($raw, true);
@@ -161,7 +166,7 @@ class CallbackEventFactorySpec extends ObjectBehavior
                   "watermark":1458668856253,
                   "seq":37
                }
-            }    
+            }
         ';
 
         $arr = json_decode($raw, true);
@@ -190,7 +195,7 @@ class CallbackEventFactorySpec extends ObjectBehavior
                   "watermark":1458668856253,
                   "seq":38
                }
-            }  
+            }
         ';
 
         $arr = json_decode($raw, true);
@@ -222,7 +227,7 @@ class CallbackEventFactorySpec extends ObjectBehavior
                 "mid":"mid.1457764197618:41d102a3e1ae206a38",
                 "seq":73
               }
-            }  
+            }
         ';
 
         $arr = json_decode($raw, true);
@@ -249,7 +254,7 @@ class CallbackEventFactorySpec extends ObjectBehavior
               "unknown":{
                 "item":"value"
               }
-            } 
+            }
         ';
 
         $arr = json_decode($raw, true);

--- a/spec/Model/Callback/MessageSpec.php
+++ b/spec/Model/Callback/MessageSpec.php
@@ -43,7 +43,7 @@ class MessageSpec extends ObjectBehavior
         $this->getAttachments()->shouldReturn(['attachment']);
     }
 
-    function its_attchaments_can_be_empty()
+    function its_attachments_can_be_empty()
     {
         $this->beConstructedWith('id', 1, null, []);
         $this->hasAttachments()->shouldReturn(false);

--- a/src/Model/Callback/Message.php
+++ b/src/Model/Callback/Message.php
@@ -125,7 +125,7 @@ class Message
     public static function create(array $payload)
     {
         $text = isset($payload['text']) ? $payload['text'] : null;
-        $attachments = isset($payload['$attachments']) ? $payload['$attachments'] : [];
+        $attachments = isset($payload['attachments']) ? $payload['attachments'] : [];
         $quickReply = isset($payload['quick_reply']) ? $payload['quick_reply']['payload'] : null;
 
         return new static($payload['mid'], $payload['seq'], $text, $attachments, $quickReply);


### PR DESCRIPTION
Hey,

I have encountered a problem while trying to work with Messenger's attachments. It seems that the current code is using `$payload['$attachments']` instead of `$payload['attachments']`. The [documentation](https://developers.facebook.com/docs/messenger-platform/webhook-reference/message) seem to suggest the same and by removing the `$` sign I have managed to fix it. 

I hope it helps :) 
Shaked