### PR TITLE
Fix cannot make abstract method getName.

### DIFF
--- a/src/Callback/CallbackEvent.php
+++ b/src/Callback/CallbackEvent.php
@@ -38,5 +38,8 @@ abstract class CallbackEvent extends Event
     /**
      * @return string
      */
-    abstract public function getName();
+    public function getName()
+    {
+        return self::NAME;
+    }
 }


### PR DESCRIPTION
getName method should not be abstract; it's not abstract in parent class. This PR fixes it.